### PR TITLE
Fix zulip icon size

### DIFF
--- a/style.scss
+++ b/style.scss
@@ -2127,7 +2127,7 @@ body >footer {
 					padding-top: 55px;
 					background-image: url(/images/zulip.svg);
 					background-repeat: no-repeat;
-					background-size: 60px 60px;
+					background-size: 40px 40px;
 					background-position: center;
 				}
 


### PR DESCRIPTION
change from 60x60 px to 40x40 to make scale more consistent with other links.